### PR TITLE
Make the Emoji suggester case insensitive

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ class EmojiSuggester extends EditorSuggest<string> {
 	}
 
 	getSuggestions(context: EditorSuggestContext): string[] {
-		let emoji_query = context.query.replace(':', '');
+		let emoji_query = context.query.replace(':', '').toLowerCase();
 		return Object.keys(emoji).filter(p => p.includes(emoji_query));
 	}
 


### PR DESCRIPTION
- Added toLowerCase() to make the suggestion case insensitive.

- **Reason**: When using the plugin on mobile and you type `:` to trigger the emoji suggester the next letter after `:` got automatically capitalized making the suggester unable to find the equivalent emoji for the typed shortcode. 