### PR TITLE
feat: support adding custom emojis from places like slackmoji.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "emoji-shortcodes",
 	"name": "Emoji Shortcodes",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"minAppVersion": "1.0.0",
 	"description": "This Plugin enables the use of Markdown Emoji Shortcodes :smile:",
 	"author": "phibr0",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,16 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@codemirror/language": "^6.12.2",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.40.0",
     "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-typescript": "^8.2.1",
     "@types/node": "^14.14.37",
-    "obsidian": "^0.12.0",
+    "obsidian": "^1.12.3",
     "rollup": "^2.32.1",
     "tslib": "^2.2.0",
-    "typescript": "4.2.3"
-  },
-  "dependencies": {}
+    "typescript": "^5.9.3"
+  }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,7 @@ export default {
     exports: 'default',
     banner,
   },
-  external: ['obsidian'],
+  external: ['obsidian', '@codemirror/view', '@codemirror/state'],
   plugins: [
     typescript(),
     nodeResolve({browser: true}),

--- a/src/definitionListPostProcessor.ts
+++ b/src/definitionListPostProcessor.ts
@@ -19,7 +19,7 @@ export default class DefinitionListPostProcessor {
                         defs: [],
                     });
                 } else if (idx !== lines.length - 1) {
-                    dlists[i].defs.push(line.substring(2));
+                    dlists[i]?.defs.push(line.substring(2));
                 }
             });
         });

--- a/src/editor/custom-emoji-view-plugin.ts
+++ b/src/editor/custom-emoji-view-plugin.ts
@@ -1,0 +1,83 @@
+import { RangeSetBuilder } from '@codemirror/state';
+import { Decoration, DecorationSet, EditorView, WidgetType, ViewPlugin, ViewUpdate } from '@codemirror/view';
+import EmojiShortcodesPlugin from '../main';
+import { checkForInputBlockEditorView } from '../util';
+
+class CustomEmojiWidget extends WidgetType {
+	constructor(readonly imgSrc: string, readonly shortcode: string) {
+		super();
+	}
+
+	toDOM(): HTMLElement {
+		const img = document.createElement('img');
+		img.src = this.imgSrc;
+		img.alt = this.shortcode;
+		img.className = 'ES-inline-emoji';
+		return img;
+	}
+
+	eq(other: CustomEmojiWidget): boolean {
+		return this.shortcode === other.shortcode;
+	}
+}
+
+export function createCustomEmojiViewPlugin(plugin: EmojiShortcodesPlugin) {
+	let lastImmediateReplace = plugin.settings.immediateReplace;
+	
+	return ViewPlugin.fromClass(
+		class {
+			decorations: DecorationSet;
+
+			constructor(view: EditorView) {
+				this.decorations = this.buildDecorations(view);
+			}
+
+			update(update: ViewUpdate) {
+				const settingChanged = plugin.settings.immediateReplace !== lastImmediateReplace;
+				if (update.docChanged || update.viewportChanged || settingChanged) {
+					lastImmediateReplace = plugin.settings.immediateReplace;
+					this.decorations = this.buildDecorations(update.view);
+				}
+			}
+
+			buildDecorations(view: EditorView): DecorationSet {
+				if (!plugin.settings.immediateReplace) {
+					return Decoration.none;
+				}
+
+				const builder = new RangeSetBuilder<Decoration>();
+				const shortcodeRegex = /:([a-z0-9_]+):/g;
+
+				for (const { from, to } of view.visibleRanges) {
+					const text = view.state.doc.sliceString(from, to);
+					let match;
+
+					while ((match = shortcodeRegex.exec(text)) !== null) {
+						const shortcode = match[0];
+						const shortcodeName = match[1];
+						const start = from + match.index;
+						const end = start + shortcode.length;
+
+						if (!checkForInputBlockEditorView(view, start)) {
+							continue;
+						}
+
+						const customEmoji = plugin.settings.customEmojis.find(e => e.shortcode === shortcodeName);
+						if (customEmoji) {
+							const imgSrc = plugin.getCustomEmojiPath(customEmoji.filename);
+							const widget = Decoration.replace({
+								widget: new CustomEmojiWidget(imgSrc, shortcode),
+							});
+							builder.add(start, end, widget);
+						}
+					}
+				}
+
+				return builder.finish();
+			}
+		},
+		{
+			decorations: (instance) => instance.decorations,
+		}
+	);
+}

--- a/src/emojiPostProcessor.ts
+++ b/src/emojiPostProcessor.ts
@@ -1,21 +1,50 @@
-import { MarkdownPostProcessor } from "obsidian";
+import { MarkdownPostProcessorContext } from "obsidian";
 import { emoji } from "./emojiList";
+import EmojiShortcodesPlugin from "./main";
 
 export default class EmojiMarkdownPostProcessor {
 
-    static emojiProcessor: MarkdownPostProcessor = (el: HTMLElement) => {
-		el.innerText.match(/[:][^\s:][^ \n:]*[:]/g)?.forEach((e: keyof typeof emoji) => EmojiMarkdownPostProcessor.emojiReplace(e, el)); 
+    static emojiProcessor = (el: HTMLElement, ctx: MarkdownPostProcessorContext, plugin: EmojiShortcodesPlugin) => {
+		const shortcodes = el.innerText.match(/[:][^\s:][^ \n:]*[:]/g);
+		if (!shortcodes) return;
+
+		shortcodes.forEach((shortcode: string) => {
+			if (plugin.isCustomEmoji(shortcode)) {
+				const customEmoji = plugin.getCustomEmoji(shortcode);
+				if (customEmoji) {
+					const imgSrc = plugin.getCustomEmojiPath(customEmoji.filename);
+					const imgTag = `<img src="${imgSrc}" alt="${shortcode}" class="ES-inline-emoji">`;
+					EmojiMarkdownPostProcessor.customEmojiReplace(shortcode, el, imgTag);
+				}
+			} else {
+				const replacement = emoji[shortcode as keyof typeof emoji] ?? shortcode;
+				EmojiMarkdownPostProcessor.emojiReplace(shortcode, el, replacement);
+			}
+		});
 	}
 
-	static emojiReplace(shortcode: keyof typeof emoji, el: HTMLElement){
-		if ((typeof el.tagName ==="string") && (el.tagName.indexOf("CODE") !== -1 || el.tagName.indexOf("MJX") !== -1)) {
-			return false;
+	static emojiReplace(shortcode: string, el: HTMLElement, replacement: string) {
+		if ((typeof el.tagName === "string") && (el.tagName.indexOf("CODE") !== -1 || el.tagName.indexOf("MJX") !== -1)) {
+			return;
 		}
-		if (el.hasChildNodes()){
-			el.childNodes.forEach((child: ChildNode) => this.emojiReplace(shortcode, child as HTMLElement));
-		} else {
-			el.textContent = el.textContent.replace(shortcode, emoji[shortcode] ?? shortcode);
+		if (el.hasChildNodes()) {
+			el.childNodes.forEach((child: ChildNode) => this.emojiReplace(shortcode, child as HTMLElement, replacement));
+		} else if (el.textContent) {
+			el.textContent = el.textContent.replace(shortcode, replacement);
 		}
 	}
 
+	static customEmojiReplace(shortcode: string, el: HTMLElement, imgTag: string) {
+		if ((typeof el.tagName === "string") && (el.tagName.indexOf("CODE") !== -1 || el.tagName.indexOf("MJX") !== -1)) {
+			return;
+		}
+		if (el.hasChildNodes()) {
+			Array.from(el.childNodes).forEach((child: ChildNode) => this.customEmojiReplace(shortcode, child as HTMLElement, imgTag));
+		} else if (el.textContent && el.textContent.includes(shortcode)) {
+			const parent = el.parentNode as HTMLElement;
+			if (parent && parent.innerHTML) {
+				parent.innerHTML = parent.innerHTML.split(shortcode).join(imgTag);
+			}
+		}
+	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,22 +1,50 @@
-import { Platform, Plugin, EditorSuggest, Editor, EditorPosition, TFile, EditorSuggestTriggerInfo, EditorSuggestContext } from 'obsidian';
-import DefinitionListPostProcessor from './definitionListPostProcessor';
+import { Plugin, EditorSuggest, Editor, EditorPosition, TFile, EditorSuggestTriggerInfo, EditorSuggestContext, normalizePath } from 'obsidian';
 import { emoji } from './emojiList';
 import EmojiMarkdownPostProcessor from './emojiPostProcessor';
 import { DEFAULT_SETTINGS, EmojiPluginSettings, EmojiPluginSettingTab } from './settings';
+import { CustomEmoji, EMOJI_FOLDER } from './types';
 import { checkForInputBlock } from './util';
+import { AddEmojiModal } from './ui/add-emoji-modal';
+import { createCustomEmojiViewPlugin } from './editor/custom-emoji-view-plugin';
 
 export default class EmojiShortcodesPlugin extends Plugin {
 
-	settings: EmojiPluginSettings;
-	emojiList: string[];
+	public settings!: EmojiPluginSettings;
+	public emojiList!: string[];
+	private emojiFolderPath!: string;
 
 	async onload() {
 		await this.loadSettings();
+		this.emojiFolderPath = normalizePath(`${this.manifest.dir}/${EMOJI_FOLDER}`);
+		await this.ensureEmojiFolder();
+		
 		this.addSettingTab(new EmojiPluginSettingTab(this.app, this));
 		this.registerEditorSuggest(new EmojiSuggester(this));
 
-		this.registerMarkdownPostProcessor(EmojiMarkdownPostProcessor.emojiProcessor);
-		//this.registerMarkdownPostProcessor(DefinitionListPostProcessor.definitionListProcessor);
+		this.registerMarkdownPostProcessor((el, ctx) => {
+			EmojiMarkdownPostProcessor.emojiProcessor(el, ctx, this);
+		});
+
+		this.registerEditorExtension(createCustomEmojiViewPlugin(this));
+
+		this.addRibbonIcon('smile-plus', 'Add Custom Emoji', () => {
+			new AddEmojiModal(this.app, this, () => {}).open();
+		});
+
+		this.addCommand({
+			id: 'add-custom-emoji',
+			name: 'Add custom emoji',
+			callback: () => {
+				new AddEmojiModal(this.app, this, () => {}).open();
+			}
+		});
+	}
+
+	private async ensureEmojiFolder() {
+		const adapter = this.app.vault.adapter;
+		if (!await adapter.exists(this.emojiFolderPath)) {
+			await adapter.mkdir(this.emojiFolderPath);
+		}
 	}
 
 	async loadSettings() {
@@ -30,12 +58,63 @@ export default class EmojiShortcodesPlugin extends Plugin {
 	}
 
 	updateEmojiList() {
-		const set = new Set(this.settings.history)
-		this.emojiList = [...this.settings.history, ...Object.keys(emoji).filter(e => !set.has(e))];
+		const historySet = new Set(this.settings.history);
+		const builtInEmojis = Object.keys(emoji).filter(e => !historySet.has(e));
+		const customEmojiKeys = this.settings.customEmojis.map(e => `:${e.shortcode}:`);
+		this.emojiList = [...customEmojiKeys, ...this.settings.history, ...builtInEmojis];
+	}
+
+	getCustomEmojiPath(filename: string): string {
+		return this.app.vault.adapter.getResourcePath(normalizePath(`${this.emojiFolderPath}/${filename}`));
+	}
+
+	isCustomEmoji(shortcode: string): boolean {
+		const code = shortcode.replace(/:/g, '');
+		return this.settings.customEmojis.some(e => e.shortcode === code);
+	}
+
+	getCustomEmoji(shortcode: string): CustomEmoji | undefined {
+		const code = shortcode.replace(/:/g, '');
+		return this.settings.customEmojis.find(e => e.shortcode === code);
+	}
+
+	async addCustomEmoji(shortcode: string, file: File): Promise<void> {
+		const ext = file.name.split('.').pop() || 'png';
+		const filename = `${shortcode}.${ext}`;
+		const filePath = normalizePath(`${this.emojiFolderPath}/${filename}`);
+		
+		const arrayBuffer = await file.arrayBuffer();
+		await this.app.vault.adapter.writeBinary(filePath, arrayBuffer);
+		
+		this.settings.customEmojis.push({
+			shortcode,
+			filename,
+			addedAt: Date.now()
+		});
+		
+		await this.saveSettings();
+	}
+
+	async deleteCustomEmoji(shortcode: string): Promise<void> {
+		const customEmoji = this.getCustomEmoji(shortcode);
+		if (!customEmoji) return;
+
+		const filePath = normalizePath(`${this.emojiFolderPath}/${customEmoji.filename}`);
+		
+		try {
+			await this.app.vault.adapter.remove(filePath);
+		} catch (e) {
+			// already deleted
+		}
+		
+		this.settings.customEmojis = this.settings.customEmojis.filter(e => e.shortcode !== shortcode);
+		await this.saveSettings();
 	}
 
 	updateHistory(suggestion: string) {
 		if (!this.settings.historyPriority) return;
+		// Don't track custom emojis in history - they're already prioritized
+		if (this.isCustomEmoji(suggestion)) return;
 
 		const set = new Set([suggestion, ...this.settings.history]);
 		const history = [...set].slice(0, this.settings.historyLimit);
@@ -55,6 +134,11 @@ class EmojiSuggester extends EditorSuggest<string> {
 
 	onTrigger(cursor: EditorPosition, editor: Editor, _: TFile): EditorSuggestTriggerInfo | null {
 		if (this.plugin.settings.suggester) {
+
+			if (!checkForInputBlock(editor, cursor.line, cursor.ch)) {
+				return null;
+			}
+
 			const sub = editor.getLine(cursor.line).substring(0, cursor.ch);
 			const match = sub.match(/:\S+$/)?.first();
 			if (match) {
@@ -79,13 +163,34 @@ class EmojiSuggester extends EditorSuggest<string> {
 	renderSuggestion(suggestion: string, el: HTMLElement): void {
 		const outer = el.createDiv({ cls: "ES-suggester-container" });
 		outer.createDiv({ cls: "ES-shortcode" }).setText(suggestion.replace(/:/g, ""));
-		//@ts-expect-error
-		outer.createDiv({ cls: "ES-emoji" }).setText(emoji[suggestion]);
+		
+		if (this.plugin.isCustomEmoji(suggestion)) {
+			const customEmoji = this.plugin.getCustomEmoji(suggestion);
+			if (customEmoji) {
+				outer.createEl('img', { 
+					cls: "ES-emoji ES-custom-emoji-img",
+					attr: { src: this.plugin.getCustomEmojiPath(customEmoji.filename) }
+				});
+			}
+		} else {
+			const emojiChar = (emoji as Record<string, string>)[suggestion];
+			outer.createDiv({ cls: "ES-emoji" }).setText(emojiChar as string);
+		}
 	}
 
 	selectSuggestion(suggestion: string): void {
 		if(this.context) {
-			(this.context.editor as Editor).replaceRange(this.plugin.settings.immediateReplace ? emoji[suggestion] : `${suggestion} `, this.context.start, this.context.end);
+			let replacement: string;
+			
+			if (this.plugin.isCustomEmoji(suggestion)) {
+				replacement = `${suggestion} `; // live view takes care of render
+			} else if (this.plugin.settings.immediateReplace) {
+				replacement = emoji[suggestion];
+			} else {
+				replacement = `${suggestion} `;
+			}
+			
+			(this.context.editor as Editor).replaceRange(replacement, this.context.start, this.context.end);
 			this.plugin.updateHistory(suggestion);
 		}
 	}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,7 @@
 import { PluginSettingTab, App, Setting } from "obsidian";
 import EmojiShortcodesPlugin from "./main";
+import { CustomEmoji } from "./types";
+import { AddEmojiModal } from "./ui/add-emoji-modal";
 
 export interface EmojiPluginSettings {
 	immediateReplace: boolean;
@@ -7,6 +9,7 @@ export interface EmojiPluginSettings {
 	historyPriority: boolean;
 	historyLimit: number;
 	history: string[];
+	customEmojis: CustomEmoji[];
 }
 
 export const DEFAULT_SETTINGS: EmojiPluginSettings = {
@@ -15,6 +18,7 @@ export const DEFAULT_SETTINGS: EmojiPluginSettings = {
 	historyPriority: true,
 	historyLimit: 100,
 	history: [],
+	customEmojis: [],
 }
 
 export class EmojiPluginSettingTab extends PluginSettingTab {
@@ -97,5 +101,39 @@ export class EmojiPluginSettingTab extends PluginSettingTab {
 			.addButton((bt) => {
 				bt.buttonEl.outerHTML = `<a href="https://ko-fi.com/phibr0"><img src="https://uploads-ssl.webflow.com/5c14e387dab576fe667689cf/61e11e22d8ff4a5b4a1b3346_Supportbutton-1.png"></a>`;
 			});
+
+		containerEl.createEl('h3', { text: 'Custom Emojis' });
+
+		new Setting(containerEl)
+			.setName('Add Custom Emoji')
+			.setDesc('Upload custom emoji images to use with shortcodes')
+			.addButton(cb => {
+				cb.setButtonText('Add Emoji')
+					.setCta()
+					.onClick(() => {
+						new AddEmojiModal(this.app, this.plugin, () => this.display()).open();
+					});
+			});
+
+		if (this.plugin.settings.customEmojis.length > 0) {
+			const emojiListContainer = containerEl.createDiv({ cls: 'ES-custom-emoji-list' });
+			
+			for (const customEmoji of this.plugin.settings.customEmojis) {
+				const emojiItem = emojiListContainer.createDiv({ cls: 'ES-custom-emoji-item' });
+				
+				emojiItem.createEl('img', {
+					cls: 'ES-custom-emoji-preview',
+					attr: { src: this.plugin.getCustomEmojiPath(customEmoji.filename) }
+				});
+				
+				emojiItem.createSpan({ text: `:${customEmoji.shortcode}:`, cls: 'ES-custom-emoji-shortcode' });
+				
+				const deleteBtn = emojiItem.createEl('button', { text: 'Delete', cls: 'ES-custom-emoji-delete' });
+				deleteBtn.addEventListener('click', async () => {
+					await this.plugin.deleteCustomEmoji(customEmoji.shortcode);
+					this.display();
+				});
+			}
+		}
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,8 @@
+export interface CustomEmoji {
+	shortcode: string;
+	filename: string;
+	addedAt: number;
+}
+
+export const EMOJI_FOLDER = 'emojis';
+export const SUPPORTED_IMAGE_TYPES = ['image/png', 'image/gif', 'image/jpeg', 'image/webp'];

--- a/src/ui/add-emoji-modal.ts
+++ b/src/ui/add-emoji-modal.ts
@@ -1,0 +1,178 @@
+import { App, Modal, Notice } from 'obsidian';
+import EmojiShortcodesPlugin from '../main';
+import { SUPPORTED_IMAGE_TYPES } from '../types';
+import { emoji } from '../emojiList';
+
+export class AddEmojiModal extends Modal {
+	plugin: EmojiShortcodesPlugin;
+	onSave: () => void;
+	
+	private selectedFile: File | null = null;
+	private previewEl: HTMLImageElement | null = null;
+	private shortcodeInput: HTMLInputElement | null = null;
+	private dropZone: HTMLElement | null = null;
+
+	constructor(app: App, plugin: EmojiShortcodesPlugin, onSave: () => void) {
+		super(app);
+		this.plugin = plugin;
+		this.onSave = onSave;
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass('ES-add-emoji-modal');
+
+		contentEl.createEl('h2', { text: 'Add emoji' });
+
+		const infoEl = contentEl.createDiv({ cls: 'ES-modal-info' });
+		infoEl.createEl('p', { 
+			text: 'Your custom emoji will be available in the emoji suggester. Square images with transparent backgrounds work best.'
+		});
+
+		contentEl.createEl('h4', { text: '1. Upload an image' });
+		
+		this.dropZone = contentEl.createDiv({ cls: 'ES-drop-zone' });
+		
+		const dropContent = this.dropZone.createDiv({ cls: 'ES-drop-zone-content' });
+		
+		this.previewEl = dropContent.createEl('img', { 
+			cls: 'ES-emoji-preview ES-hidden',
+			attr: { alt: 'Preview' }
+		});
+		
+		const dropText = dropContent.createDiv({ cls: 'ES-drop-text' });
+		dropText.createSpan({ text: 'Drag and drop or\n\n' });
+		
+		const uploadBtn = dropText.createEl('button', { text: 'Upload Image', cls: 'ES-upload-btn' });
+		uploadBtn.addEventListener('click', () => this.openFilePicker());
+
+		this.setupDragAndDrop();
+
+		contentEl.createEl('h4', { text: '2. Give it a name' });
+		contentEl.createEl('p', { 
+			cls: 'ES-shortcode-desc',
+			text: 'This is what you\'ll type to add this emoji to your notes.'
+		});
+
+		const shortcodeContainer = contentEl.createDiv({ cls: 'ES-shortcode-container' });
+		shortcodeContainer.createSpan({ text: ':', cls: 'ES-shortcode-prefix' });
+		this.shortcodeInput = shortcodeContainer.createEl('input', {
+			type: 'text',
+			cls: 'ES-shortcode-input',
+			attr: { placeholder: 'custom_emoji' }
+		});
+		shortcodeContainer.createSpan({ text: ':', cls: 'ES-shortcode-suffix' });
+
+		const buttonContainer = contentEl.createDiv({ cls: 'ES-modal-buttons' });
+		
+		const cancelBtn = buttonContainer.createEl('button', { text: 'Cancel' });
+		cancelBtn.addEventListener('click', () => this.close());
+		
+		const saveBtn = buttonContainer.createEl('button', { text: 'Save', cls: 'mod-cta' });
+		saveBtn.addEventListener('click', () => this.saveEmoji());
+	}
+
+	private setupDragAndDrop() {
+		if (!this.dropZone) return;
+
+		this.dropZone.addEventListener('dragover', (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			this.dropZone?.addClass('ES-drag-over');
+		});
+
+		this.dropZone.addEventListener('dragleave', (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			this.dropZone?.removeClass('ES-drag-over');
+		});
+
+		this.dropZone.addEventListener('drop', (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			this.dropZone?.removeClass('ES-drag-over');
+			
+			const file = e.dataTransfer?.files[0];
+			if (file) {
+				this.handleFile(file);
+			}
+		});
+	}
+
+	private openFilePicker() {
+		const input = document.createElement('input');
+		input.type = 'file';
+		input.accept = SUPPORTED_IMAGE_TYPES.join(',');
+		input.onchange = () => {
+			if (input.files?.[0]) {
+				this.handleFile(input.files[0]);
+			}
+		};
+		input.click();
+	}
+
+	private handleFile(file: File) {
+		if (SUPPORTED_IMAGE_TYPES.indexOf(file.type) === -1) {
+			new Notice('Please select a valid image file (PNG, GIF, JPG, or WEBP)');
+			return;
+		}
+
+		this.selectedFile = file;
+		
+		const reader = new FileReader();
+		reader.onload = (e) => {
+			if (this.previewEl && e.target?.result) {
+				this.previewEl.src = e.target.result as string;
+				this.previewEl.removeClass('ES-hidden');
+				this.dropZone?.addClass('ES-has-image');
+			}
+		};
+		reader.readAsDataURL(file);
+
+		if (this.shortcodeInput && !this.shortcodeInput.value) {
+			const nameWithoutExt = file.name.replace(/\.[^.]+$/, '');
+			const cleanName = nameWithoutExt.toLowerCase().replace(/[^a-z0-9_]/g, '_');
+			this.shortcodeInput.value = cleanName;
+		}
+	}
+
+	private async saveEmoji() {
+		if (!this.selectedFile) {
+			new Notice('Please select an image first');
+			return;
+		}
+
+		const shortcode = this.shortcodeInput?.value?.trim().toLowerCase().replace(/[^a-z0-9_]/g, '_');
+		if (!shortcode) {
+			new Notice('Please enter a shortcode');
+			return;
+		}
+
+		const existingCustom = this.plugin.settings.customEmojis.find(e => e.shortcode === shortcode);
+		if (existingCustom) {
+			new Notice(`Shortcode ":${shortcode}:" already exists`);
+			return;
+		}
+
+		// Check built-in emojis
+		if (emoji[`:${shortcode}:`]) {
+			new Notice(`Shortcode ":${shortcode}:" conflicts with a built-in emoji`);
+			return;
+		}
+
+		try {
+			await this.plugin.addCustomEmoji(shortcode, this.selectedFile);
+			new Notice(`Custom emoji ":${shortcode}:" added!`);
+			this.onSave();
+			this.close();
+		} catch (error) {
+			new Notice(`Failed to save emoji: ${error}`);
+		}
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+	}
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,46 @@
-export function checkForInputBlock(
-    cmEditor: CodeMirror.Editor,
-    cursorPos: CodeMirror.Position,
-  ): boolean {
-    const tokenType = cmEditor.getTokenAt(cursorPos, true).type;
-    return (typeof(tokenType) !== "string") || (tokenType.indexOf("code") === -1 && tokenType.indexOf("math") === -1); // "code" matches "inline-code" or "codeblock"
-  }
+import { EditorView } from '@codemirror/view';
+import { Editor } from 'obsidian';
+
+export function checkForInputBlock(editor: Editor, line: number, ch: number): boolean {
+	const lineText = editor.getLine(line);
+
+	const beforeCursor = lineText.substring(0, ch);
+	const backtickCount = (beforeCursor.match(/`/g) || []).length;
+	if (backtickCount % 2 === 1) {
+		return false; // Inside inline code
+	}
+
+	let insideFence = false;
+	for (let i = 0; i <= line; i++) {
+		const text = editor.getLine(i);
+		if (text.match(/^```/)) {
+			insideFence = !insideFence;
+		}
+	}
+	
+	return !insideFence;
+}
+
+// separate checker for livepreview, uses CM6
+export function checkForInputBlockEditorView(view: EditorView, pos: number): boolean {
+	const doc = view.state.doc;
+	const line = doc.lineAt(pos);
+	const lineText = line.text;
+	const ch = pos - line.from;
+	
+	const beforeCursor = lineText.substring(0, ch);
+	const backtickCount = (beforeCursor.match(/`/g) || []).length;
+	if (backtickCount % 2 === 1) {
+		return false;
+	}
+
+	let insideFence = false;
+	for (let i = 1; i <= line.number; i++) {
+		const text = doc.line(i).text;
+		if (text.match(/^```/)) {
+			insideFence = !insideFence;
+		}
+	}
+	
+	return !insideFence;
+}

--- a/styles.css
+++ b/styles.css
@@ -29,3 +29,186 @@ a[href="https://ko-fi.com/phibr0"]
   padding-left: 0;
   margin-left: 2em;
 }
+
+/* Add Emoji Modal */
+.ES-add-emoji-modal {
+  padding: 20px;
+}
+
+.ES-add-emoji-modal h2 {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.ES-add-emoji-modal h4 {
+  margin-top: 20px;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+
+.ES-modal-info {
+  color: var(--text-muted);
+  font-size: 0.9em;
+  margin-bottom: 16px;
+}
+
+.ES-drop-zone {
+  border: 2px dashed var(--background-modifier-border);
+  border-radius: 8px;
+  padding: 40px 20px;
+  text-align: center;
+  transition: all 0.2s ease;
+  white-space: pre;
+  cursor: pointer;
+  background: var(--background-secondary);
+}
+
+.ES-drop-zone:hover {
+  border-color: var(--interactive-accent);
+  background: var(--background-secondary-alt);
+}
+
+.ES-drop-zone.ES-drag-over {
+  border-color: var(--interactive-accent);
+  background: var(--background-modifier-hover);
+}
+
+.ES-drop-zone.ES-has-image {
+  padding: 20px;
+}
+
+.ES-drop-zone-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.ES-emoji-preview {
+  max-width: 128px;
+  max-height: 128px;
+  object-fit: contain;
+  border-radius: 4px;
+}
+
+.ES-emoji-preview.ES-hidden {
+  display: none;
+}
+
+.ES-drop-text {
+  color: var(--text-muted);
+}
+
+.ES-upload-btn {
+  background: var(--interactive-normal);
+  border: 1px solid var(--background-modifier-border);
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text-normal);
+}
+
+.ES-upload-btn:hover {
+  background: var(--interactive-hover);
+}
+
+.ES-shortcode-desc {
+  color: var(--text-muted);
+  font-size: 0.9em;
+  margin-bottom: 8px;
+}
+
+.ES-shortcode-container {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  padding: 8px 12px;
+}
+
+.ES-shortcode-prefix,
+.ES-shortcode-suffix {
+  color: var(--text-muted);
+  font-family: var(--font-monospace);
+}
+
+.ES-shortcode-input {
+  border: none;
+  background: transparent;
+  flex: 1;
+  font-family: var(--font-monospace);
+  color: var(--text-normal);
+  outline: none;
+}
+
+.ES-modal-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 24px;
+}
+
+/* Inline Custom Emoji */
+.ES-inline-emoji {
+  height: 1.4em;
+  vertical-align: middle;
+  display: inline;
+}
+
+/* Suggester Custom Emoji */
+.ES-custom-emoji-img {
+  height: 1.5em;
+  width: 1.5em;
+  object-fit: contain;
+}
+
+/* Settings Custom Emoji List */
+.ES-custom-emoji-list {
+  margin-top: 16px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.ES-custom-emoji-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.ES-custom-emoji-item:last-child {
+  border-bottom: none;
+}
+
+.ES-custom-emoji-preview {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+}
+
+.ES-custom-emoji-shortcode {
+  flex: 1;
+  font-family: var(--font-monospace);
+  color: var(--text-muted);
+}
+
+.ES-custom-emoji-delete {
+  background: transparent;
+  border: 1px solid var(--background-modifier-border);
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 0.85em;
+}
+
+.ES-custom-emoji-delete:hover {
+  background: var(--background-modifier-error);
+  color: var(--text-on-accent);
+  border-color: var(--background-modifier-error);
+}
+


### PR DESCRIPTION
## Changes
- Adds ribbon button and modal for emoji upload
- Added support for PNG, GIF, JPEG, and WebP
- Implemented unused code block check
- Upgraded Codemirror to 6 used by Obsidian now
- general cleanup

I've tested for backwards compatibility and feature parity. Demo below
![Demo](https://i.imgur.com/v28bfSI.gif)
[https://i.imgur.com/v28bfSI.gif](https://i.imgur.com/v28bfSI.gif)